### PR TITLE
Dataflow and unroll decorator

### DIFF
--- a/sycl/include/sycl/ext/xilinx/fpga.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga.hpp
@@ -20,5 +20,6 @@
 #include "sycl/ext/xilinx/fpga/memory_properties.hpp"
 #include "sycl/ext/xilinx/fpga/partition_array.hpp"
 #include "sycl/ext/xilinx/fpga/pipeline.hpp"
+#include "sycl/ext/xilinx/fpga/unroll.hpp"
 
 #endif // SYCL_XILINX_FPGA_HPP

--- a/sycl/include/sycl/ext/xilinx/fpga.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga.hpp
@@ -20,6 +20,7 @@
 #include "sycl/ext/xilinx/fpga/memory_properties.hpp"
 #include "sycl/ext/xilinx/fpga/partition_array.hpp"
 #include "sycl/ext/xilinx/fpga/pipeline.hpp"
+#include "sycl/ext/xilinx/fpga/parallel_invoke.hpp"
 #include "sycl/ext/xilinx/fpga/unroll.hpp"
 
 #endif // SYCL_XILINX_FPGA_HPP

--- a/sycl/include/sycl/ext/xilinx/fpga.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga.hpp
@@ -14,8 +14,8 @@
 #ifndef SYCL_XILINX_FPGA_HPP
 #define SYCL_XILINX_FPGA_HPP
 
-
 #include "sycl/ext/xilinx/fpga/kernel_param.hpp"
+#include "sycl/ext/xilinx/fpga/dataflow.hpp"
 #include "sycl/ext/xilinx/fpga/kernel_properties.hpp"
 #include "sycl/ext/xilinx/fpga/memory_properties.hpp"
 #include "sycl/ext/xilinx/fpga/partition_array.hpp"

--- a/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
@@ -1,0 +1,52 @@
+//==- dataflow.hpp --- SYCL Xilinx extension ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file includes some decorating functions and kernel properties related
+/// to dataflow support by Xilinx tools.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_XILINX_FPGA_DATAFLOW
+#define SYCL_XILINX_FPGA_DATAFLOW
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+
+#include "CL/sycl/detail/defines.hpp"
+#include "sycl/ext/xilinx/fpga/kernel_properties.hpp"
+
+__SYCL_INLINE_NAMESPACE(cl) {
+
+namespace sycl {
+namespace ext::xilinx {
+
+
+
+/** 
+  Turn on dataflow optimisation for a loop
+*/
+template <typename T>
+__SYCL_DEVICE_ANNOTATE("xilinx_dataflow")
+__SYCL_ALWAYS_INLINE void dataflow(T &&functor) {
+  std::forward<T>(functor)();
+}
+
+auto dataflow_kernel(auto kernel) {
+  using kernelType = std::remove_cvref_t<decltype(kernel)>;
+  return detail::KernelDecorator<kernelType, decltype(&kernelType::operator()), decltype("kernel_dataflow"_cstr), 0>{
+      kernel};
+}
+} // namespace xilinx
+} // namespace sycl
+
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+#endif

--- a/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
@@ -30,7 +30,7 @@ namespace ext::xilinx {
 
 
 
-/** 
+/**
   Turn on dataflow optimisation for a loop
 */
 template <typename T>
@@ -41,8 +41,8 @@ __SYCL_ALWAYS_INLINE void dataflow(T &&functor) {
 
 auto dataflow_kernel(auto kernel) {
   using kernelType = std::remove_cvref_t<decltype(kernel)>;
-  return detail::KernelDecorator<kernelType, decltype(&kernelType::operator()), decltype("kernel_dataflow"_cstr), 0>{
-      kernel};
+  return detail::KernelDecorator<kernelType, decltype(&kernelType::operator()),
+                                 decltype("kernel_dataflow"_cstr), 0>{kernel};
 }
 } // namespace xilinx
 } // namespace sycl

--- a/sycl/include/sycl/ext/xilinx/fpga/parallel_invoke.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/parallel_invoke.hpp
@@ -1,0 +1,91 @@
+//==- parallel_invoke.hpp --- SYCL Xilinx loop unrolling       -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CL/sycl/detail/defines.hpp"
+
+#ifndef SYCL_XILINX_FPGA_PARALLEL_INVOKE_HPP
+#define SYCL_XILINX_FPGA_PARALLEL_INVOKE_HPP
+
+__SYCL_INLINE_NAMESPACE(cl) {
+
+namespace sycl {
+
+namespace ext::xilinx {
+namespace detail {
+template <int firstStep, int firstOutStep, int inc>
+void inline normalized_parallel_invoke(auto &loop_step, auto &&loop_condition,
+                                       int first, int bound) {
+  if constexpr (firstOutStep - firstStep <= 1) {
+    // Actual call step
+    constexpr int localInc = firstStep * inc;
+    int callIdx = first + localInc;
+    if (loop_condition(callIdx, bound)) {
+      loop_step(callIdx);
+    }
+  } else {
+    // Subdivide call sequence
+    constexpr int midpoint = (firstStep + firstOutStep) / 2;
+    normalized_parallel_invoke<firstStep, midpoint, inc>(
+        loop_step,
+        loop_condition, first, bound);
+
+    normalized_parallel_invoke<midpoint, firstOutStep, inc>(
+        loop_step,
+        loop_condition, first, bound);
+  }
+}
+
+template <int firstNormalizedStep, int firstNormalizedOutStep, int offset,
+          int inc>
+void inline normalized_full_parallel_invoke(auto &loop_step) {
+  if constexpr (firstNormalizedOutStep - firstNormalizedStep <= 1) {
+    // Actual call step
+    constexpr int localInc = firstNormalizedStep * inc;
+    int callIdx = offset + localInc;
+    loop_step(callIdx);
+  } else {
+    // Subdivide call sequence
+    constexpr int midpoint = (firstNormalizedStep + firstNormalizedOutStep) / 2;
+    normalized_full_parallel_invoke<firstNormalizedStep, midpoint, offset, inc>(
+        loop_step);
+
+    normalized_full_parallel_invoke<midpoint, firstNormalizedOutStep, offset,
+                                    inc>(loop_step);
+  }
+}
+} // namespace detail
+
+template <int unrollFactor = 1, int increment = 1>
+inline void parallel_invoke(auto &loop_step, auto &loop_condition, int start,
+                            int bound) {
+
+  static_assert(unrollFactor >= 1, "Parallel invoke requires a strictly "
+                                   "positive unfold factor. For full "
+                                   "parallel unrolling use "
+                                   "full_parallel_invoke");
+  static_assert(increment != 0, "parallel_invoke increment cannot be zero");
+  constexpr int newIncrement = unrollFactor * increment;
+  for (int i = start;
+       loop_condition(i, bound);
+       i += newIncrement)
+    detail::normalized_parallel_invoke<0, unrollFactor, increment>(
+        loop_step,
+        loop_condition, i, bound);
+}
+
+template <int startIdx, int nbSteps, int increment = 1>
+inline void full_parallel_invoke(auto &loop_step) {
+  static_assert(nbSteps > 0, "Trying to unroll a loop of 0 steps");
+  detail::normalized_full_parallel_invoke<0, nbSteps, startIdx, increment>(
+      loop_step);
+}
+} // namespace ext::xilinx
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+#endif

--- a/sycl/include/sycl/ext/xilinx/fpga/unroll.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/unroll.hpp
@@ -1,0 +1,74 @@
+//==- unroll.hpp --- SYCL Xilinx native loop unrolling       -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_XILINX_FPGA_UNROLL_HPP
+#define SYCL_XILINX_FPGA_UNROLL_HPP
+
+#include "CL/sycl/detail/defines.hpp"
+
+__SYCL_INLINE_NAMESPACE(cl) {
+
+namespace sycl {
+namespace ext::xilinx {
+namespace detail {
+template <unsigned int UnrollFactor> struct ConstrainedUnrolling {
+  static_assert(
+      UnrollFactor > 1,
+      "Constrained unrolling factor should be strictly greater than one");
+  static constexpr unsigned int UnrollingFactor = UnrollFactor;
+  static constexpr bool FullUnroll = false;
+};
+} // namespace detail
+
+template <unsigned int UnrollFactor>
+struct CheckedFixedUnrolling
+    : public detail::ConstrainedUnrolling<UnrollFactor> {
+  static constexpr bool checked = true;
+};
+
+template <unsigned int UnrollFactor>
+struct UncheckedFixedUnrolling
+    : public detail::ConstrainedUnrolling<UnrollFactor> {
+  static constexpr bool checked = false;
+};
+
+struct FullUnrolling {
+  static constexpr bool FullUnroll = true;
+  static constexpr unsigned int UnrollingFactor = 0;
+  static constexpr bool checked = false;
+};
+
+struct NoUnrolling {
+  static constexpr bool FullUnroll = false;
+  static constexpr unsigned int UnrollingFactor = 1;
+  static constexpr bool checked = false;
+};
+
+/** Xilinx loop unrolling.
+
+  unroll a loop
+
+ \tparam UnrollType determines the type of unrolling to perform. Can be
+ (Un)CheckedFixedUnrolling<>, FullUnrolling or NoUnrolling
+
+ \tparam T type of the functor to execute
+*/
+template <typename UnrollType = FullUnrolling, typename T>
+__SYCL_ALWAYS_INLINE void unroll(T &&functor) {
+  __SYCL_DEVICE_ANNOTATE("xilinx_unroll", UnrollType::UnrollingFactor,
+                        UnrollType::checked)
+  int annotationAnchor;
+  (void)annotationAnchor;
+  std::forward<T>(functor)();
+}
+
+} // namespace ext::xilinx
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+#endif

--- a/sycl/tools/sycl-vxx/bin/sycl_vxx.py
+++ b/sycl/tools/sycl-vxx/bin/sycl_vxx.py
@@ -144,7 +144,8 @@ class CompilationDriver:
                 "-flat-address-space=0", "-globaldce"
             ])
         opt_options.extend([
-            "-O3", "-globaldce", "-globaldce", "-inSPIRation",
+            "--vectorize-loops=false", "--disable-loop-unrolling", "-O3",
+            "-globaldce", "-globaldce", "-inSPIRation",
             "-o", f"{self.optimised_bc}"
         ])
 
@@ -189,6 +190,7 @@ class CompilationDriver:
             f"{self.outstem}-kernels_properties.json"
         )
         opt_options = [
+            "--lower-delayed-sycl-metadata", "-lower-sycl-metadata",
             "--sycl-vxx", "--sycl-prepare-clearspir", "-S", "-preparesycl",
             "-kernelPropGen",
             "--sycl-kernel-propgen-output", f"{kernel_prop}",
@@ -200,7 +202,7 @@ class CompilationDriver:
         subprocess.run(args, check=True)
         with kernel_prop.open('r') as kp_fp:
             self.kernel_properties = json.load(kp_fp)
-        opt_options = ["--sycl-vxx", "-S", "-O3", "-vxxIRDowngrader"]
+        opt_options = ["--sycl-vxx", "-S", "-vxxIRDowngrader"]
         self.downgraded_ir = (
             self.tmpdir / f"{self.outstem}_kernels-linked.opt.ll")
         args = [


### PR DESCRIPTION
Based on #129 
Also adds a few modifications to the annotation system, to allow late lowering of SYCL annotations.
This is required in the unroll case, otherwise the loop unrolling is performed before feeding IR to HLS, which can create false problems when use in conjunction with dataflow.