### PR TITLE
Conversion of sycl_vxx.py vitis compile and link config path to absolute

### DIFF
--- a/sycl/tools/sycl-vxx/bin/sycl_vxx.py
+++ b/sycl/tools/sycl-vxx/bin/sycl_vxx.py
@@ -240,7 +240,7 @@ class CompilationDriver:
             self.vpp_llvm_input
         ]
         if comp_config is not None and Path(comp_config).is_file():
-            command.extend(("--config", comp_config))
+            command.extend(("--config", Path(comp_config).resolve()))
         if 'extra_args' in kernel and kernel['extra_args'].strip():
             # User provided kernel arguments can contain many spaces,
             # leading split to give empty string that are incorrectly
@@ -271,7 +271,7 @@ class CompilationDriver:
             "--save-temps", "-l", "-o", self.outpath
         ]
         if link_config is not None and Path(link_config).is_file():
-            command.extend(("--config", link_config))
+            command.extend(("--config", Path(link_config).resolve()))
         for kernelprop in self.kernel_properties['kernels']:
             targets = dict()
             for mem_assign in kernelprop["bundle_hw_mapping"]:


### PR DESCRIPTION
As discussed in the comments of PR #137 