### PR TITLE
Fix ignored -fsycl-unnamed-lambda (#145)

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -559,6 +559,8 @@ static llvm::Optional<unsigned> SYCLMangleCallback(ASTContext &Ctx,
   return llvm::None;
 }
 
+std::string computeUniqueSYCLVXXName(StringRef Demangle);
+
 std::string SYCLUniqueStableNameExpr::ComputeName(ASTContext &Context,
                                                   QualType Ty) {
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
@@ -569,7 +571,7 @@ std::string SYCLUniqueStableNameExpr::ComputeName(ASTContext &Context,
   llvm::raw_string_ostream Out(Buffer);
   Ctx->mangleTypeName(Ty, Out);
 
-  return Out.str();
+  return computeUniqueSYCLVXXName(Out.str());
 }
 
 SYCLUniqueStableIdExpr::SYCLUniqueStableIdExpr(EmptyShell Empty,
@@ -684,7 +686,7 @@ StringRef PredefinedExpr::getIdentKindName(PredefinedExpr::IdentKind IK) {
 }
 
 /// Compute a unique name that is consumable by sycl_vxx
-std::string computeUniqueSYCLVXXName(StringRef Name, StringRef Demangle) {
+std::string computeUniqueSYCLVXXName(StringRef Demangle) {
   /// VXX has a maximum of 64 character for the name of the kernel function
   /// plus the name of one parameter.
   /// Those characters need to be used wisely to prevent name collisions.
@@ -747,8 +749,8 @@ std::string computeUniqueSYCLVXXName(StringRef Name, StringRef Demangle) {
   /// repeated. This doesn't hurt entropy too much because it is just 2 out
   /// of 64.
   Result += llvm::SHA1::hashToString(
-      llvm::ArrayRef<uint8_t>{reinterpret_cast<const uint8_t *>(Name.data()),
-                              Name.size()},
+      llvm::ArrayRef<uint8_t>{reinterpret_cast<const uint8_t *>(Demangle.data()),
+                              Demangle.size()},
       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       "abcdefghijklmnopqrstuvwxyz"
       "0123456789AB");

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3976,7 +3976,6 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
                          options::OPT_fno_sycl_allow_variadic_func)
           : Args.hasFlag(options::OPT_fsycl_allow_variadic_func,
                          options::OPT_fno_sycl_allow_variadic_func, false);
-  Opts.SYCLUnnamedLambda = Args.hasArg(options::OPT_fsycl_unnamed_lambda);
 
   // Get OpenMP host file path if any and report if a non existent file is
   // found

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1074,8 +1074,6 @@ static QualType calculateKernelNameType(ASTContext &Ctx,
   return TAL->get(0).getAsType().getCanonicalType();
 }
 
-std::string computeUniqueSYCLVXXName(StringRef Name, StringRef Demangle);
-
 // Gets a name for the OpenCL kernel function, calculated from the first
 // template argument of the kernel caller function.
 static std::pair<std::string, std::string>
@@ -1092,7 +1090,6 @@ constructKernelName(Sema &S, const FunctionDecl *KernelCallerFunc,
   std::string Res = std::string(Out.str());
   std::string Str =
       SYCLUniqueStableNameExpr::ComputeName(S.getASTContext(), KernelNameType);
-  Res = computeUniqueSYCLVXXName(Res, KernelNameType.getAsString());
   return {Res, Str};
 }
 


### PR DESCRIPTION
Leftover from merge, due to change of the option handling in upstream.