### PR TITLE
Add generic_executor test from triSYCL

### DIFF
--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -61,19 +61,15 @@ auto generic_executor(auto op, auto... inputs) {
         output.template get_access<sycl::access::mode::discard_write>(cgh);
 
     // Define the kernel
-    // Does not compile: candidate template ignored: couldn't infer template
-    // argument 'IIType' cgh.single_task(sycl::ext::xilinx::pipeline_kernel([=]
-    // {
     cgh.single_task([=] {
-      sycl::ext::xilinx::pipeline([&] {
-        for (int i = 0; i < size; ++i) {
+      for (int i = 0; i < size; ++i)
+        sycl::ext::xilinx::pipeline([&] {
           // Pack operands an elemental computation in a tuple
           auto operands =
               boost::hana::transform(ka, [&](auto acc) { return acc[i]; });
           // Assign computation on the operands to the elemental result
           ko[i] = compute(operands);
-        }
-      });
+        });
     });
   });
   // Return the output buffer

--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -29,7 +29,7 @@ static selector_defines::CompiledForDeviceSelector selector;
    folding them with a given generic operator */
 auto generic_executor(auto op, auto... inputs) {
   // Use a tuple of heterogeneous buffers to wrap the inputs
-  auto a = boost::hana::make_tuple(
+  auto bufs = boost::hana::make_tuple(
       sycl::buffer{std::begin(inputs), std::end(inputs)}...);
 
   /* The element-wise computation
@@ -41,7 +41,7 @@ auto generic_executor(auto op, auto... inputs) {
 
   /* Use the range of the first argument as the range
      of the result and computation */
-  auto size = a[0_c].size();
+  auto size = bufs[0_c].size();
 
   // Infer the type of the output from 1 computation on inputs
   using return_value_type =
@@ -53,7 +53,7 @@ auto generic_executor(auto op, auto... inputs) {
   // Submit a command-group to the device
   sycl::queue{selector}.submit([&](sycl::handler &cgh) {
     // Define the data used as a tuple of read accessors
-    auto ka = boost::hana::transform(a, [&](auto b) {
+    auto ka = boost::hana::transform(bufs, [&](auto b) {
       return sycl::accessor{b, cgh, sycl::read_only};
     });
     // Data are produced to a write accessor to the output buffer

--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -6,6 +6,7 @@
    Simple example showing how SYCL provide single-source genericity
    enabling writing generic templated libraries
 */
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <list>
@@ -80,8 +81,8 @@ auto generic_executor(auto op, auto... inputs) {
 };
 
 int main() {
-  std::vector<int> u{1, 2, 3};
-  std::vector<float> v{5, 6, 7};
+  std::vector<std::int8_t> u{1, 2, 3};
+  std::vector<std::int16_t> v{5, 6, 7};
 
   // Do not use std::plus because it forces the same type for both operands
   auto res = generic_executor([](auto x, auto y) { return x + y; }, u, v);

--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -20,7 +20,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace boost::hana::literals;
-;
 
 // Use sycl::host_selector for debug
 static selector_defines::CompiledForDeviceSelector selector;
@@ -28,10 +27,9 @@ static selector_defines::CompiledForDeviceSelector selector;
 /* A generic function taking any number of arguments of any type and
    folding them with a given generic operator */
 auto generic_executor = [](auto op, auto... inputs) {
-  // Use a tupple of heterogeneous buffers to wrap the inputs
+  // Use a tuple of heterogeneous buffers to wrap the inputs
   auto a = boost::hana::make_tuple(
-      sycl::buffer<typename decltype(inputs)::value_type>{std::begin(inputs),
-                                                          std::end(inputs)}...);
+      sycl::buffer{std::begin(inputs), std::end(inputs)}...);
 
   /* The element-wise computation
 

--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -92,7 +92,7 @@ int main() {
   std::list<float> c{-55, 6.5, -7.5, 0};
   auto res2 =
       generic_executor([](auto x, auto y) { return 3 * x - 7 * y; }, a, b, c);
-  for (sycl::host_accessor a{res, sycl::read_only};
+  for (sycl::host_accessor a{res2, sycl::read_only};
        auto e : std::span{&a[0], a.size()})
     std::cout << e << ' ';
   std::cout << std::endl;

--- a/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
+++ b/sycl/test/on-device/xocc/simple_tests/generic_executor.cpp
@@ -26,7 +26,7 @@ static selector_defines::CompiledForDeviceSelector selector;
 
 /* A generic function taking any number of arguments of any type and
    folding them with a given generic operator */
-auto generic_executor = [](auto op, auto... inputs) {
+auto generic_executor(auto op, auto... inputs) {
   // Use a tuple of heterogeneous buffers to wrap the inputs
   auto a = boost::hana::make_tuple(
       sycl::buffer{std::begin(inputs), std::end(inputs)}...);
@@ -50,7 +50,7 @@ auto generic_executor = [](auto op, auto... inputs) {
   sycl::buffer<return_value_type> output{size};
 
   // Submit a command-group to the device
-  sycl::queue{sycl::host_selector{}}.submit([&](sycl::handler &cgh) {
+  sycl::queue{selector}.submit([&](sycl::handler &cgh) {
     // Define the data used as a tuple of read accessors
     auto ka = boost::hana::transform(a, [&](auto b) {
       return b.template get_access<sycl::access::mode::read>(cgh);


### PR DESCRIPTION
Example for CppCon 2021 presentation.
Modernized version of
https://github.com/triSYCL/triSYCL/blob/master/tests/examples/generic_executor.cpp