### PR TITLE
Remove unused boost includes

### DIFF
--- a/sycl/include/sycl/ext/xilinx/fpga/kernel_properties.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/kernel_properties.hpp
@@ -18,7 +18,6 @@
 
 #include "sycl/ext/xilinx/literals/cstr.hpp"
 #include "CL/sycl/detail/pi.h"
-#include <boost/core/demangle.hpp>
 #include <cstddef>
 #include <iostream>
 #include <regex>

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -26,10 +26,6 @@
 #include <detail/spec_constant_impl.hpp>
 #include <sycl/ext/oneapi/experimental/spec_constant.hpp>
 
-#include <boost/container_hash/hash.hpp> // uuid_hasher
-#include <boost/uuid/uuid_generators.hpp> // sha name_gen/generator
-#include <boost/uuid/uuid_io.hpp> // uuid to_string
-
 #include <algorithm>
 #include <cassert>
 #include <cstdint>


### PR DESCRIPTION
Those were not used. And now one can build sycl without having boost headers installed.