### PR TITLE
[SYCL][Vitis] Add sycl::ext::xilinx::annot to apply multiple annotations of the same loop.

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2712,7 +2712,7 @@ void CodeGenFunction::EmitVarAnnotations(const VarDecl *D, llvm::Value *V) {
   // llvm-gcc was doing.
   for (const auto *I : D->specific_attrs<AnnotateAttr>())
     EmitAnnotationCall(CGM.getIntrinsic(llvm::Intrinsic::var_annotation),
-                       Builder.CreateBitCast(V, CGM.Int8PtrTy, V->getName()),
+                       Builder.CreatePointerCast(V, CGM.Int8PtrTy, V->getName()),
                        I->getAnnotation(), D->getLocation(), I);
 }
 

--- a/llvm/lib/SYCL/LowerSYCLMetaData.cpp
+++ b/llvm/lib/SYCL/LowerSYCLMetaData.cpp
@@ -288,7 +288,7 @@ public:
   ///
   /// @param CS Payload of the original annotation
   void lowerUnrollDecoration(llvm::CallBase &CB,
-                             llvm::ConstantStruct *Payload) {
+                             llvm::Constant *Payload) {
     auto *F = CB.getCaller();
 
     // Metadata payload is unroll factor (first argument) and boolean indicating
@@ -436,11 +436,10 @@ public:
     bool processed = false;
     if (Kind == kindOf("xilinx_ddr_bank") || Kind == kindOf("xilinx_hbm_bank"))
       return;
-    auto *Payload = cast<ConstantStruct>(PayloadCst);
     if (AfterO3) { // Annotation that should wait after optimisation to be
                    // lowered
       if (Kind == kindOf("xilinx_unroll")) {
-        lowerUnrollDecoration(CB, Payload);
+        lowerUnrollDecoration(CB, PayloadCst);
         processed = true;
       }
     }

--- a/sycl/doc/GettingStartedXilinxFPGA.md
+++ b/sycl/doc/GettingStartedXilinxFPGA.md
@@ -27,6 +27,7 @@
         1. [Loop unrolling](#Loop-unrolling)
         1. [Pinning allocators to specific memory banks](#Pinning-allocators-to-specific-memory-banks)
         1. [Array partitioning](#Array-partitioning)
+        1. [Multiple annotations](#Multiple-annotations)
     1. [AMD/Xilinx Macros](#AMDXilinx-Macros)
     1. [xsim issues](#xsim-issues)
 1. [Implementation](#Implementation)
@@ -1436,6 +1437,20 @@ queue.submit([&](sycl::handler &cgh) {
 ```
 
 for more examples see [this test case](../test/vitis/simple_tests/partion_ndarray.cpp) or [this one](../test/vitis/edge_detection/edge_detection.cpp)
+
+### Multiple annotations
+
+It is also possible to apply multiple annotations on the same loop by using ``sycl::ext::xilinx::annot`` like the following:
+
+```cpp
+/// assuming
+using namespace sycl::ext::xilinx
+
+for (int i = 0; i < a.get_size(); i++)
+  annot<pipeline<>, unroll<checked_fixed_unrolling<8>>>([&] { a[i] = 0; });
+```
+
+This loop will be pipelined with default settings and unrolled by a factor of 8
 
 ## AMD/Xilinx Macros
 

--- a/sycl/include/sycl/ext/xilinx/fpga.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga.hpp
@@ -14,6 +14,7 @@
 #ifndef SYCL_XILINX_FPGA_HPP
 #define SYCL_XILINX_FPGA_HPP
 
+#include "sycl/ext/xilinx/fpga/annotate.hpp"
 #include "sycl/ext/xilinx/fpga/kernel_param.hpp"
 #include "sycl/ext/xilinx/fpga/dataflow.hpp"
 #include "sycl/ext/xilinx/fpga/kernel_properties.hpp"

--- a/sycl/include/sycl/ext/xilinx/fpga/annotate.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/annotate.hpp
@@ -1,0 +1,28 @@
+//==- dataflow.hpp --- SYCL Xilinx extension -------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This contains utility to apply multiple annotations on a loop
+///
+//===----------------------------------------------------------------------===//
+
+#include <utility>
+#include "sycl/detail/defines.hpp"
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+
+namespace ext::xilinx {
+
+template <typename... params, typename T> void annot(T func) {
+  (params([] {}), ...);
+  func();
+}
+}
+}
+}

--- a/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/dataflow.hpp
@@ -1,4 +1,4 @@
-//==- dataflow.hpp --- SYCL Xilinx extension ---------------==//
+//==- dataflow.hpp --- SYCL Xilinx extension -------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -31,11 +31,13 @@ namespace ext::xilinx {
 /**
   Turn on dataflow optimisation for a loop
 */
-template <typename T>
-__SYCL_DEVICE_ANNOTATE("xilinx_dataflow")
-__SYCL_ALWAYS_INLINE void dataflow(T &&functor) {
-  std::forward<T>(functor)();
-}
+struct dataflow {
+  template <typename T>
+  __SYCL_DEVICE_ANNOTATE("xilinx_dataflow")
+  __SYCL_ALWAYS_INLINE dataflow(T functor) {
+    functor();
+  };
+};
 
 auto dataflow_kernel(auto kernel) {
   using kernelType = std::remove_cvref_t<decltype(kernel)>;

--- a/sycl/include/sycl/ext/xilinx/fpga/pipeline.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/pipeline.hpp
@@ -65,15 +65,23 @@ using disable_pipeline = std::integral_constant<int, 0>;
   \tparam T type of the functor to execute
 */
 template <typename IIType = auto_ii, typename rewindtype = no_rewind_pipeline,
-          pipeline_style pipelineType = pipeline_style::stall, typename T>
-__SYCL_DEVICE_ANNOTATE("xilinx_pipeline", IIType::value, rewindtype::value, pipelineType)
-__SYCL_ALWAYS_INLINE void pipeline(T &&functor) { std::forward<T>(functor)(); }
+          pipeline_style pipelineType = pipeline_style::stall>
+struct pipeline {
+    template <typename T>
+    __SYCL_DEVICE_ANNOTATE("xilinx_pipeline", IIType::value, rewindtype::value,
+                           pipelineType)
+    __SYCL_ALWAYS_INLINE pipeline(T functor) {
+      functor();
+    }
+};
 
-template <typename T>
-__SYCL_DEVICE_ANNOTATE("xilinx_pipeline", 0, false, pipeline_style::stall)
-__SYCL_ALWAYS_INLINE void noPipeline(T &&functor) {
-  std::forward<T>(functor)();
-}
+struct noPipeline {
+    template <typename T>
+    __SYCL_DEVICE_ANNOTATE("xilinx_pipeline", 0, false, pipeline_style::stall)
+    __SYCL_ALWAYS_INLINE noPipeline(T functor) {
+      functor();
+    }
+};
 
 template <typename IIType = auto_ii, pipeline_style pipelineType = pipeline_style::stall>
 auto pipeline_kernel(auto kernel) {

--- a/sycl/include/sycl/ext/xilinx/fpga/unroll.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/unroll.hpp
@@ -60,14 +60,17 @@ struct no_unrolling {
 
  \tparam T type of the functor to execute
 */
-template <typename UnrollType = full_unrolling, typename T>
-__SYCL_ALWAYS_INLINE void unroll(T &&functor) {
+template <typename UnrollType = full_unrolling>
+struct unroll {
+  template<typename T>
+  __SYCL_ALWAYS_INLINE unroll(T functor) {
   __SYCL_DEVICE_ANNOTATE("xilinx_unroll", UnrollType::UnrollingFactor,
-                        UnrollType::checked)
+                         UnrollType::checked)
   int annotationAnchor;
   (void)annotationAnchor;
-  std::forward<T>(functor)();
-}
+  functor();
+  }
+};
 
 } // namespace ext::xilinx
 }

--- a/sycl/test/vitis/simple_tests/loop_annotations.cpp
+++ b/sycl/test/vitis/simple_tests/loop_annotations.cpp
@@ -1,0 +1,37 @@
+// REQUIRES: vitis
+
+// RUN: rm -rf %t.dir && mkdir %t.dir && cd %t.dir
+// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%sycl_triple %s -o %t.dir/exec.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.dir/exec.out
+
+#include <sycl.hpp>
+#include <sycl/ext/xilinx/fpga.hpp>
+
+namespace xlx = sycl::ext::xilinx;
+
+int main() {
+  sycl::buffer<int> answer{1};
+  sycl::queue q;
+
+  q.submit([&](sycl::handler &cgh) {
+    sycl::accessor a{answer, cgh, sycl::write_only};
+    cgh.single_task<class forty_two>([=] {
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::pipeline([&] { a[i] = 0; });
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::pipeline<>([&] { a[i] = 0; });
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::annot<xlx::pipeline<>>([&] { a[i] = 0; });
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::annot<xlx::pipeline<>, xlx::unroll<>>([&] { a[i] = 0; });
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::annot<xlx::pipeline<xlx::constrained_ii<1>>,
+                   xlx::unroll<xlx::checked_fixed_unrolling<8>>>(
+            [&] { a[i] = 0; });
+      for (int i = 0; i < a.get_size(); i++)
+        xlx::annot<xlx::unroll<xlx::checked_fixed_unrolling<8>>,
+                   xlx::dataflow>(
+            [&] { a[i] = 0; });
+    });
+  });
+}

--- a/sycl/test/vitis/simple_tests/multi_device.cpp
+++ b/sycl/test/vitis/simple_tests/multi_device.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: vitis && cuda_be
+// REQUIRES: vitis && cuda_be && !vitis_cpu
 
 // RUN: rm -rf %t.dir && mkdir %t.dir && cd %t.dir
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-libspirv-path=%llvm_build_lib_dir./clc/libspirv-nvptx64--nvidiacl.bc -fsycl-targets=nvptx64-nvidia-cuda-sycldevice,%sycl_triple %s -o %t.dir/exec.out  -###


### PR DESCRIPTION

also fix a few compiler crashes with annotations.