### PR TITLE
[SYCL][Driver] do not generate device (for FPGA) code with PIC

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5700,7 +5700,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-mrelocation-model");
     CmdArgs.push_back(RMName);
   }
-  if (PICLevel > 0) {
+  /// PIC is not needed for device SYCL code and it causes issues for Xilinx HLS backend
+  if (PICLevel > 0 && !Triple.isXilinxFPGA()) {
     CmdArgs.push_back("-pic-level");
     CmdArgs.push_back(PICLevel == 1 ? "1" : "2");
     if (IsPIE)


### PR DESCRIPTION
PIC has no impact on the device side

also add documentation about an issue that can occure when using dynamic librairies