### PR TITLE
PLRAM support

### DIFF
--- a/llvm/include/llvm/SYCL/KernelProperties.h
+++ b/llvm/include/llvm/SYCL/KernelProperties.h
@@ -50,7 +50,7 @@ private:
   
   // BundlesBySpec[MemType][MemID] contains the index of the 
   // Bundle of the bank MemType:MemID in Bundles
-  std::array<SmallDenseMap<unsigned, unsigned, 4>, 3> BundlesBySpec;
+  std::array<SmallDenseMap<unsigned, unsigned, 4>, 4> BundlesBySpec;
   SmallDenseMap<Argument *, unsigned, 16> BundleForArgument;
   StringMap<unsigned> BundlesByName;
   SmallVector<MAXIBundle, 8> Bundles;

--- a/llvm/include/llvm/SYCL/SYCLUtils.h
+++ b/llvm/include/llvm/SYCL/SYCLUtils.h
@@ -74,7 +74,7 @@ void removePipeAnnotation(Argument *Arg);
 /// Rename arguments to comply with Vitis's HLS
 void giveNameToArguments(Function &F);
 
-enum struct MemoryType { unspecified, ddr, hbm };
+enum struct MemoryType { unspecified, ddr, hbm, plram };
 
 struct MemBankSpec {
   MemoryType MemType;

--- a/llvm/lib/SYCL/KernelPropGen.cpp
+++ b/llvm/lib/SYCL/KernelPropGen.cpp
@@ -211,6 +211,9 @@ struct KernelPropGenState {
               case sycl::MemoryType::hbm:
               Prefix = "HBM";
               break;
+              case sycl::MemoryType::plram:
+              Prefix = "PLRAM";
+              break;
               default:
               llvm_unreachable("Default bundle should not appear here");
             }

--- a/llvm/lib/SYCL/KernelProperties.cpp
+++ b/llvm/lib/SYCL/KernelProperties.cpp
@@ -54,6 +54,9 @@ KernelProperties::KernelProperties(Function &F) {
             case sycl::MemoryType::hbm:
             Prefix = "hb";
             break;
+            case sycl::MemoryType::plram:
+            Prefix = "pl";
+            break;
             default:
             llvm_unreachable("Default type should not appear here");
           }

--- a/llvm/lib/SYCL/LowerSYCLMetaData.cpp
+++ b/llvm/lib/SYCL/LowerSYCLMetaData.cpp
@@ -94,6 +94,8 @@ void collectUserSpecifiedBanks(
       MemT = sycl::MemoryType::ddr;
     else if (Str->getRawDataValues() == kindOf("xilinx_hbm_bank"))
       MemT = sycl::MemoryType::hbm;
+    else if (Str->getRawDataValues() == kindOf("xilinx_plram_bank"))
+      MemT = sycl::MemoryType::plram;
     else
       continue;
     Constant *Args =
@@ -434,7 +436,7 @@ public:
                                llvm::Constant *PayloadCst) {
     auto Kind = KindInit->getRawDataValues();
     bool processed = false;
-    if (Kind == kindOf("xilinx_ddr_bank") || Kind == kindOf("xilinx_hbm_bank"))
+    if (Kind == kindOf("xilinx_ddr_bank") || Kind == kindOf("xilinx_hbm_bank") || Kind == kindOf("xilinx_plram_bank"))
       return;
     if (AfterO3) { // Annotation that should wait after optimisation to be
                    // lowered

--- a/llvm/lib/SYCL/SYCLUtils.cpp
+++ b/llvm/lib/SYCL/SYCLUtils.cpp
@@ -193,7 +193,7 @@ void giveNameToArguments(Function &F) {
 }
 
 void annotateMemoryBank(Argument *Arg, MemBankSpec Bank) {
-  const auto mem_type = [&Bank](){
+  const auto mem_type = [&Bank] {
     if (Bank.MemType == MemoryType::ddr)
         return sycl::xilinx_ddr_bank;
     if (Bank.MemType == MemoryType::hbm)

--- a/sycl/include/sycl/ext/xilinx/fpga/memory_properties.hpp
+++ b/sycl/include/sycl/ext/xilinx/fpga/memory_properties.hpp
@@ -47,6 +47,18 @@ struct hbm_bank {
     }
   };
 };
+
+struct plram_bank {
+  template <unsigned A> struct instance {
+    template <int B> constexpr bool operator==(const instance<B> &) const {
+      return A == B;
+    }
+    template <int B> constexpr bool operator!=(const instance<B> &) const {
+      return A != B;
+    }
+  };
+};
+
 } // namespace property
 
 template <typename... Ts>
@@ -57,6 +69,9 @@ template <int A> inline constexpr property::ddr_bank::instance<A> ddr_bank;
 
 template <int A> inline constexpr property::hbm_bank::instance<A> hbm_bank;
 
+
+template <int A> inline constexpr property::plram_bank::instance<A> plram_bank;
+
 } // namespace xilinx
 
 namespace oneapi {
@@ -65,6 +80,9 @@ struct is_compile_time_property<xilinx::property::ddr_bank> : std::true_type {};
 
 template <>
 struct is_compile_time_property<xilinx::property::hbm_bank> : std::true_type {};
+
+template <>
+struct is_compile_time_property<xilinx::property::plram_bank> : std::true_type {};
 } // namespace oneapi
 } // namespace ext
 
@@ -75,6 +93,10 @@ struct IsCompileTimePropertyInstance<ext::xilinx::property::ddr_bank::instance<I
 
 template <int I>
 struct IsCompileTimePropertyInstance<ext::xilinx::property::hbm_bank::instance<I>>
+    : std::true_type {};
+
+    template <int I>
+struct IsCompileTimePropertyInstance<ext::xilinx::property::plram_bank::instance<I>>
     : std::true_type {};
 } // namespace detail
 

--- a/sycl/test/vitis/simple_tests/memory_types_test.cpp
+++ b/sycl/test/vitis/simple_tests/memory_types_test.cpp
@@ -9,7 +9,7 @@
 #include <sycl/ext/xilinx/fpga.hpp>
 
 int main() {
-  sycl::buffer<int, 1> BufferA{4}, BufferB{4}, BufferC{4};
+  sycl::buffer<std::size_t, 1> BufferA{4}, BufferB{4}, BufferC{4};
   sycl::queue Queue{};
   const std::size_t buf_size{BufferA.size()};
 

--- a/sycl/test/vitis/simple_tests/memory_types_test.cpp
+++ b/sycl/test/vitis/simple_tests/memory_types_test.cpp
@@ -5,7 +5,7 @@
 // RUN: %run_if_not_cpu FileCheck --input-file=%t.check %s
 // RUN: %ACC_RUN_PLACEHOLDER %t.dir/exec.out
 
-#include <sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/xilinx/fpga.hpp>
 
 int main() {

--- a/sycl/test/vitis/simple_tests/memory_types_test.cpp
+++ b/sycl/test/vitis/simple_tests/memory_types_test.cpp
@@ -7,37 +7,34 @@
 
 #include <sycl/sycl.hpp>
 #include <sycl/ext/xilinx/fpga.hpp>
+#include <numeric>
 
 int main() {
   sycl::buffer<std::size_t, 1> BufferA{4}, BufferB{4}, BufferC{4};
   sycl::queue Queue{};
-  const std::size_t buf_size{BufferA.size()};
 
   Queue.submit([&](sycl::handler &cgh) {
     sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::ddr_bank<1>};
     // CHECK-DAG:{{.*}}:DDR[1]
     sycl::accessor Accessor(BufferA, cgh, sycl::write_only, PL);
     cgh.single_task<class SmallerTesta>([=]{
-          for (std::size_t i = 0 ; i < buf_size ; ++i)
-            Accessor[i] = i;
-        });
+      std::iota(Accessor.begin(), Accessor.end(), 0);
+    });
   });
   Queue.submit([&](sycl::handler &cgh) {
     sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::hbm_bank<0>};
     // CHECK-DAG:{{.*}}:HBM[0]
     sycl::accessor Accessor(BufferB, cgh, sycl::write_only, PL);
     cgh.single_task<class SmallerTestb>([=]{
-          for (std::size_t i = 0 ; i < buf_size ; ++i)
-            Accessor[i] = i;
-        });
+      std::iota(Accessor.begin(), Accessor.end(), 0);
+    });
   });
   Queue.submit([&](sycl::handler &cgh) {
     sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::plram_bank<1>};
     // CHECK-DAG:{{.*}}:PLRAM[1]
     sycl::accessor Accessor(BufferC, cgh, sycl::write_only, PL);
     cgh.single_task<class SmallerTestc>([=]{
-          for (std::size_t i = 0 ; i < buf_size ; ++i)
-            Accessor[i] = i;
-        });
+      std::iota(Accessor.begin(), Accessor.end(), 0);
+    });
   });
 }

--- a/sycl/test/vitis/simple_tests/memory_types_test.cpp
+++ b/sycl/test/vitis/simple_tests/memory_types_test.cpp
@@ -1,0 +1,43 @@
+// REQUIRES: vitis
+
+// RUN: rm -rf %t.dir && mkdir %t.dir && cd %t.dir
+// RUN: %clangxx %EXTRA_COMPILE_FLAGS-fsycl -std=c++20 -fsycl-targets=%sycl_triple %s -o %t.dir/exec.out > %t.check 2>&1
+// RUN: %run_if_not_cpu FileCheck --input-file=%t.check %s
+// RUN: %ACC_RUN_PLACEHOLDER %t.dir/exec.out
+
+#include <sycl.hpp>
+#include <sycl/ext/xilinx/fpga.hpp>
+
+int main() {
+  sycl::buffer<int, 1> BufferA{4}, BufferB{4}, BufferC{4};
+  sycl::queue Queue{};
+  const std::size_t buf_size{BufferA.size()};
+
+  Queue.submit([&](sycl::handler &cgh) {
+    sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::ddr_bank<1>};
+    // CHECK-DAG:{{.*}}:DDR[1]
+    sycl::accessor Accessor(BufferA, cgh, sycl::write_only, PL);
+    cgh.single_task<class SmallerTesta>([=]{
+          for (std::size_t i = 0 ; i < buf_size ; ++i)
+            Accessor[i] = i;
+        });
+  });
+  Queue.submit([&](sycl::handler &cgh) {
+    sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::hbm_bank<0>};
+    // CHECK-DAG:{{.*}}:HBM[0]
+    sycl::accessor Accessor(BufferB, cgh, sycl::write_only, PL);
+    cgh.single_task<class SmallerTestb>([=]{
+          for (std::size_t i = 0 ; i < buf_size ; ++i)
+            Accessor[i] = i;
+        });
+  });
+  Queue.submit([&](sycl::handler &cgh) {
+    sycl::ext::oneapi::accessor_property_list PL{sycl::ext::xilinx::plram_bank<1>};
+    // CHECK-DAG:{{.*}}:PLRAM[1]
+    sycl::accessor Accessor(BufferC, cgh, sycl::write_only, PL);
+    cgh.single_task<class SmallerTestc>([=]{
+          for (std::size_t i = 0 ; i < buf_size ; ++i)
+            Accessor[i] = i;
+        });
+  });
+}


### PR DESCRIPTION
This adds support for PLRAM memory 'banks'. In most cases it is just cloning the implementation of DDR/HBM with minor adjustments.

I agree that `sycl/include/sycl/ext/xilinx/fpga/memory_properties.hpp` deserves some refactoring (and even more with plram case), but I didn't try to do that in this PR as I don't know if you have specific plans for that.